### PR TITLE
Fix form usage code

### DIFF
--- a/classes/modules/class-admin-interface.php
+++ b/classes/modules/class-admin-interface.php
@@ -285,7 +285,7 @@ class AdminInterface extends Module {
 
     <!-- Ugly but it works as intended -->
     <code>&lt;?php
-$form = new \WPLF\Form(\WPLF\getFormPostObject(<?=absint($post->ID)?>));
+$form = new \WPLF\Form(\get_post(<?=absint($post->ID)?>));
 echo libreform()->render($form); ?&gt;</code>
     <?php
   }

--- a/classes/modules/class-admin-interface.php
+++ b/classes/modules/class-admin-interface.php
@@ -285,8 +285,8 @@ class AdminInterface extends Module {
 
     <!-- Ugly but it works as intended -->
     <code>&lt;?php
-$form = new \WPLF\Form(getFormPostObject(<?=absint($post->ID)?>));
-libreform()->render($form); ?&gt;</code>
+$form = new \WPLF\Form(\WPLF\getFormPostObject(<?=absint($post->ID)?>));
+echo libreform()->render($form); ?&gt;</code>
     <?php
   }
 


### PR DESCRIPTION
### Reference Issue/s
Fixes [#25 Fatal error when inserting form via PHP ](https://github.com/libreform/libreform/issues/25).

### Details
Added `\WPLF\` to `getFormPostObject()` to properly resolve namespace. Used `echo` to output HTML markup.

