### PR TITLE
Fix server side treatment of '0', blank values, and spaces

### DIFF
--- a/classes/entities/class-form.php
+++ b/classes/entities/class-form.php
@@ -319,17 +319,15 @@ class Form {
     foreach ($fields as $field) {
       $required = $field['required'];
       $name = $field['name'];
-      $value = $formEntries[$name] ?? false;
+      $value = $formEntries[$name] ?? '';
 
       // This used to be an empty() call but then it turned out that empty() sucks; "0" is apparently empty. All values from forms are strings, and "0" is a valid form value.
-      $valueIsEmpty = $value === false ? true : !(strlen($value) > 0);
+      $isBlank = $value === '';
 
-      if ($required && $valueIsEmpty) {
+      if ($required && $isBlank) {
         $missing[] = $name;
       }
     }
-
-
 
     if (!empty($missing)) {
       throw new Error(__('Required fields are missing.', 'wplf'), [

--- a/classes/entities/class-submission.php
+++ b/classes/entities/class-submission.php
@@ -55,7 +55,7 @@ class Submission {
 
     foreach ($this->rawData as $name => $v) {
       if (strpos($name, 'field') === 0) {
-        $this->entries[$this->form->getFieldOriginalName($name)] = $v;
+        $this->entries[$this->form->getFieldOriginalName($name)] = trim($v);
       } elseif ($name === 'meta') {
         $this->meta = json_decode($v);
       } else {

--- a/classes/modules/class-selectors.php
+++ b/classes/modules/class-selectors.php
@@ -53,7 +53,7 @@ class Selectors extends Module {
             }
 
             $type = $formField['type'];
-            $isEmpty = empty($value);
+            $isBlank = $value === '';
 
             // Avoid leaking file location in the selector:
             // Return the value using the filter if you want to enable it, or create your own selector.
@@ -62,7 +62,7 @@ class Selectors extends Module {
               $value = apply_filters('wplfSubmissionSelectorFileFieldValue', $str, $value, $formField);
             }
 
-            if ($isEmpty) {
+            if ($isBlank) {
               // Empty string makes for a terrible visual.
               $value = apply_filters('wplfEmptySubmissionFieldValue', __('(empty)', 'wplf'));
             }


### PR DESCRIPTION
This PR fixes the following:

- Submitted value of '0' is wrongly interpreted as empty
- '0' is saved and displayed as '(empty)'
- Leading and trailing spaces are not removed in submitted values

Renamed variable $isEmpty to $isBlank for readability. Simplified and minimized code changes as much as possible.

Related to #28