### PR TITLE
Actually destroy history

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ WP Libre Form is built upon the "WYSIWYG" principle. We use the HTML you supply 
 ## Server requirements
 
 - PHP 7.3 or newer
-- **MariaDB**, MySQL mostly works but [as it turns out](https://github.com/libreform/libreform/issues/22) I managed to code a vendorlokki.
+- **MariaDB**,
+  - ~~MySQL mostly works but [as it turns out](https://github.com/libreform/libreform/issues/22) I managed to code a vendorlokki.~~
+  - MySQL probably no longer works as the table creation code depends on `ADD COLUMN IF NOT EXISTS` and `DROP COLUMN IF EXISTS`
+  - If you really _really_ need to run it on MySQL, you can hot-patch the offending lines in class-db-io.php so they don't use the missing `IF EXISTS` feature. As long as you don't use the field deletion feature (link above), you should be good to go.
 
 ## Further reading
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -438,6 +438,9 @@ class Plugin {
         }
 
         $this->io->db->updateFormSubmissionsTable($form, $newFields, $deletedFields);
+
+        // The history of the form also has to go. Otherwise the field names stay reserved.
+        $this->io->db->destroyHistoryFields($form);
       }
     } catch (Error $e) {
       $msg = $e->getMessage();

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -439,8 +439,10 @@ class Plugin {
 
         $this->io->db->updateFormSubmissionsTable($form, $newFields, $deletedFields);
 
-        // The history of the form also has to go. Otherwise the field names stay reserved.
-        $this->io->db->destroyHistoryFields($form);
+        if ($deletedFields) {
+          // The history of the form also has to go. Otherwise the field names stay reserved.
+          $this->io->db->destroyHistoryFields($form);
+        }
       }
     } catch (Error $e) {
       $msg = $e->getMessage();

--- a/classes/modules/io/class-db-io.php
+++ b/classes/modules/io/class-db-io.php
@@ -88,7 +88,7 @@ class DbIo extends Module {
         }
 
         $addedNames[] = $name;
-        $addSql = $addSql . "ADD COLUMN `$name` $fieldDefinition, ";
+        $addSql = $addSql . "ADD COLUMN IF NOT EXISTS `$name` $fieldDefinition, ";
       }
     }
 
@@ -104,7 +104,7 @@ class DbIo extends Module {
     $addSql = rtrim($addSql, ', ');
     $dropSql = rtrim($dropSql, ', ');
 
-    $alterQuery = rtrim($dropFields ? "$dropSql, $addSql" : $addSql, ',');
+    $alterQuery = rtrim(($dropFields ? "$dropSql, $addSql" : $addSql), ', ');
 
     if (
         !$db->query("

--- a/classes/modules/io/class-db-io.php
+++ b/classes/modules/io/class-db-io.php
@@ -88,6 +88,7 @@ class DbIo extends Module {
         }
 
         $addedNames[] = $name;
+        // This IF EXISTS clause is NOT MySQL compatible.
         $addSql = $addSql . "ADD COLUMN IF NOT EXISTS `$name` $fieldDefinition, ";
       }
     }
@@ -97,6 +98,7 @@ class DbIo extends Module {
         $name = $field['name'];
         $name = $form->getFieldColumnName($name);
 
+        // This IF EXISTS clause is NOT MySQL compatible.
         $dropSql = $dropSql . "DROP COLUMN IF EXISTS `$name`, ";
       }
     }
@@ -104,7 +106,10 @@ class DbIo extends Module {
     $addSql = rtrim($addSql, ', ');
     $dropSql = rtrim($dropSql, ', ');
 
-    $alterQuery = rtrim(($dropFields ? "$dropSql, $addSql" : $addSql), ', ');
+    $alterQuery = rtrim(
+      $dropFields ? "$dropSql, $addSql" : $addSql,
+      ', '
+    );
 
     if (
         !$db->query("

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Plugin name: Libre Form
  * Plugin URI: https://github.com/libreform/libre-form
  * Description: A minimal HTML form builder for WordPress; made for developers
- * Version: 2.0.5
+ * Version: 2.0.6
  * Author: Libre Form
  * Author URI: https://github.com/libreform/
  * License: GPLv2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libreform/libreform",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "WP Libre Form client",
   "main": "dist/wplf-frontend",
   "types": "dist/wplf-frontend",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2719615/115040435-1d813c00-9eda-11eb-8834-4c75d46a756d.png)

Highlighted part wasn't happening, because the query wasn't trimmed properly. Upon fixing it, I realised that after the history has been destroyed, all fields are being treated as new ones, and thus the code attempts to create columns for those "new" fields. Now it checks for column existence before. 

That **probably** breaks MySQL entirely. #22 