### PR TITLE
Stop throwing an error if history cannot be deleted

### DIFF
--- a/classes/modules/io/class-db-io.php
+++ b/classes/modules/io/class-db-io.php
@@ -223,7 +223,9 @@ class DbIo extends Module {
     if ($db->delete($tableName, ['formId' => $form->ID], ['%d'])) {
       return true;
     } else {
-      throw new Error('Unable to destroy history entry!', [$form]);
+      log('Unable to destroy history entry in form {$form->ID}');
+      
+      return false;
     }
   }
 }


### PR DESCRIPTION
This is the first time I've managed to get it to error out in the first place. In this case I had duplicated a form with Duplicate Post which broke something. The form was not able to be deleted permanently as it errored to this. The cause of the error was a missing table.

I'm leaving this hanging for now as there might be implications for changing the behaviour, and as stated, the error didn't even happen without using a 3rd party plugin.